### PR TITLE
chore: update README heading

### DIFF
--- a/packages/theme-apple-basic/README.md
+++ b/packages/theme-apple-basic/README.md
@@ -1,4 +1,4 @@
-# @slidev/theme-apple
+# @slidev/theme-apple-basic
 
 [![NPM version](https://img.shields.io/npm/v/@slidev/theme-apple-basic?color=3AB9D4&label=)](https://www.npmjs.com/package/@slidev/theme-apple-basic)
 


### PR DESCRIPTION
From `@slidev/theme-apple` to `@slidev/theme-apple-basic`. This matches the package's name, and might help avoid confusion (I tried to install `@slidev/theme-apple` out of habit).