### PR TITLE
Fix handleBackground helper to work with colors

### DIFF
--- a/packages/theme-default/layoutHelper.ts
+++ b/packages/theme-default/layoutHelper.ts
@@ -10,7 +10,7 @@ export function resolveAssetUrl(url: string) {
 }
 
 export function handleBackground(background?: string, dim = false): CSSProperties {
-  const isColor = background && background[0] === '#' && background.startsWith('rgb')
+  const isColor = background?.[0] === '#' || background?.startsWith('rgb')
 
   const style = {
     background: isColor


### PR DESCRIPTION
Colors weren't actually working because `isColor` was checking for hex `#` AND `rgb` instead of hex `#` OR `rgb`.

Swapped the background variable truthy test for the newer `background?` syntax