### PR TITLE
fix: handleBackground helper colors all themes

### DIFF
--- a/packages/theme-apple-basic/layoutHelper.ts
+++ b/packages/theme-apple-basic/layoutHelper.ts
@@ -10,7 +10,7 @@ export function resolveAssetUrl(url: string) {
 }
 
 export function handleBackground(background?: string, dim = false): CSSProperties {
-  const isColor = background && background[0] === '#' && background.startsWith('rgb')
+  const isColor = background && ['#', 'rgb', 'hsl'].some(v => background.indexOf(v) === 0)
 
   const style = {
     background: isColor

--- a/packages/theme-bricks/layoutHelper.ts
+++ b/packages/theme-bricks/layoutHelper.ts
@@ -10,7 +10,7 @@ export function resolveAssetUrl(url: string) {
 }
 
 export function handleBackground(background?: string, dim = false): CSSProperties {
-  const isColor = background && background[0] === '#' && background.startsWith('rgb')
+  const isColor = background && ['#', 'rgb', 'hsl'].some(v => background.indexOf(v) === 0)
 
   const style = {
     background: isColor

--- a/packages/theme-default/layoutHelper.ts
+++ b/packages/theme-default/layoutHelper.ts
@@ -10,7 +10,7 @@ export function resolveAssetUrl(url: string) {
 }
 
 export function handleBackground(background?: string, dim = false): CSSProperties {
-  const isColor = background?.[0] === '#' || background?.startsWith('rgb')
+  const isColor = background && ['#', 'rgb', 'hsl'].some(v => background.indexOf(v) === 0)
 
   const style = {
     background: isColor

--- a/packages/theme-seriph/layoutHelper.ts
+++ b/packages/theme-seriph/layoutHelper.ts
@@ -10,7 +10,7 @@ export function resolveAssetUrl(url: string) {
 }
 
 export function handleBackground(background?: string, dim = false): CSSProperties {
-  const isColor = background && background[0] === '#' && background.startsWith('rgb')
+  const isColor = background && ['#', 'rgb', 'hsl'].some(v => background.indexOf(v) === 0)
 
   const style = {
     background: isColor


### PR DESCRIPTION
Belatedly realized the other themes also used this function, and that the function didnt support `hsl` colors. This should fix all the themes that have the `handleBackground` function and add `hsl` detection.