### PR TITLE
fix(apple-basic): margin bottom instead of top

### DIFF
--- a/packages/theme-apple-basic/styles/layout.css
+++ b/packages/theme-apple-basic/styles/layout.css
@@ -42,7 +42,7 @@
 
   ul {
     list-style: disc;
-    @apply mt-4;
+    @apply mb-4;
   }
 
   li {


### PR DESCRIPTION
### Before
![before](https://user-images.githubusercontent.com/34672141/171908348-ae055673-e8f3-4f5c-9c82-7817f5c8cf27.png)

### After
![after](https://user-images.githubusercontent.com/34672141/171908364-87cf4897-3cce-43bd-864f-fa873c1bfdbc.png)

I feel like bottom margin is more intuitive, making more visual sense :smile: Anyone agree?

By the way, thanks for developing such wonderful tool :heart:
