### PR TITLE
fix(seriph): correct boldface and italics

### DIFF
--- a/packages/theme-seriph/package.json
+++ b/packages/theme-seriph/package.json
@@ -18,7 +18,9 @@
       "fonts": {
         "mono": "PT Mono",
         "sans": "PT Serif",
-        "serif": "PT Serif"
+        "serif": "PT Serif",
+        "italic": true,
+        "weights": "400, 700"
       }
     }
   },


### PR DESCRIPTION
As requested in #9. Tested locally.

Closes #9.