### PR TITLE
Remove backticks from code blocks

### DIFF
--- a/packages/theme-default/styles/prism.css
+++ b/packages/theme-default/styles/prism.css
@@ -63,7 +63,6 @@ html.dark {
 
 :not(pre) > code:before,
 :not(pre) > code:after {
-  content: '`';
   opacity: 0.50;
 }
 

--- a/packages/theme-seriph/styles/prism.css
+++ b/packages/theme-seriph/styles/prism.css
@@ -63,7 +63,6 @@ html.dark {
 
 :not(pre) > code:before,
 :not(pre) > code:after {
-  content: '`';
   opacity: 0.50;
 }
 


### PR DESCRIPTION
## Description

Currently, backticks are being placed at the start and end of code blocks. This goes against the normal behaviour of code blocks in most systems (for example, GitHub and GitLab - if you use in line code blocks you don't see the backticks).

## Proposed change

This PR proposes to remove the backticks that are being written in by CSS in the default and the serif themes. 

No other themes were modified as part of this PR. 

Thanks.